### PR TITLE
Make clear that the labeling is a GMail only feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A simple Node-RED (http://nodered.org) node to perform operations on emails retr
 # Features
 
 * Leaves original payload unchanged
-* Optionally Adds lables to emails
+* Optionally Adds lables to emails (__GMail-only__ feature)
 * Optionally moves emails to a specified folder
 
 # Install


### PR DESCRIPTION
I tried to use this node and got stuck with an unclear error message caused by trying to set a label. After some googling my deduction is this is a Gmail-only feature. If this is true. This PR would make this clear for future users.